### PR TITLE
Enhancement: Group E features (cache invalidation, datalist, error messages, import page)

### DIFF
--- a/src/money_mapper/api/server.py
+++ b/src/money_mapper/api/server.py
@@ -436,6 +436,10 @@ def create_app(data_dir: str | None = None) -> FastAPI:
             with open(new_mappings_path, "w") as f:
                 toml_writer.dump(existing, f)
 
+            from money_mapper.transaction_enricher import clear_pattern_cache
+
+            clear_pattern_cache()
+
             safe_merchant = html.escape(str(cleaned_merchant))
             safe_category = html.escape(str(category))
             return HTMLResponse(

--- a/src/money_mapper/api/server.py
+++ b/src/money_mapper/api/server.py
@@ -321,26 +321,28 @@ def create_app(data_dir: str | None = None) -> FastAPI:
                     raw_path, enriched_output, debug=False, use_multiprocessing=False
                 )
                 enriched = _load_enriched_transactions(enriched_output)
-                from money_mapper.api.validation import format_warnings_html
-
+                template = env.get_template("import_result.html")
                 msg = f"Imported {len(transactions)} transactions, {len(enriched)} enriched"
-                safe_msg = html.escape(msg)
-                warnings_html = format_warnings_html(importer.warnings)
-                return HTMLResponse(safe_msg + warnings_html, status_code=200)
+                result_html = template.render(
+                    title="Import Results",
+                    message=msg,
+                    warnings=importer.warnings,
+                    active_page="import",
+                )
+                return HTMLResponse(result_html, status_code=200)
             except Exception:
-                from money_mapper.api.validation import format_warnings_html
-
+                template = env.get_template("import_result.html")
                 count = len(transactions)
-                warning_msg = (
-                    f"Imported {count} transactions. "
-                    f"Warning: enrichment failed -- categories not applied."
+                all_warnings = list(importer.warnings) + [
+                    "Enrichment failed -- categories not applied"
+                ]
+                result_html = template.render(
+                    title="Import Results",
+                    message=f"Imported {count} transactions",
+                    warnings=all_warnings,
+                    active_page="import",
                 )
-                safe_msg = html.escape(warning_msg)
-                warnings_html = format_warnings_html(importer.warnings)
-                return HTMLResponse(
-                    f'<div class="warning">{safe_msg}</div>{warnings_html}',
-                    status_code=207,
-                )
+                return HTMLResponse(result_html, status_code=207)
 
         except Exception as e:
             safe_err = html.escape(str(e))
@@ -372,6 +374,19 @@ def create_app(data_dir: str | None = None) -> FastAPI:
         except Exception:
             pass
 
+        plaid_path = os.path.join(base_dir, "config", "plaid_categories.toml")
+        pfc_categories = []
+        try:
+            with open(plaid_path, "rb") as f:
+                plaid_data = tomllib.load(f)
+            for primary_val in plaid_data.values():
+                if isinstance(primary_val, dict):
+                    for detailed_key in primary_val:
+                        pfc_categories.append(detailed_key)
+            pfc_categories.sort()
+        except (OSError, tomllib.TOMLDecodeError):
+            pass
+
         data = {
             "title": "Mappings",
             "active_page": "mappings",
@@ -380,6 +395,7 @@ def create_app(data_dir: str | None = None) -> FastAPI:
                 {"merchant": m["name"], "category": m["category"]} for m in private
             ],
             "privacy_warnings": warnings if warnings else None,
+            "pfc_categories": pfc_categories,
         }
         return HTMLResponse(template.render(**data))
 

--- a/src/money_mapper/api/templates/import_result.html
+++ b/src/money_mapper/api/templates/import_result.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}Import Results - Money Mapper{% endblock %}
+
+{% block content %}
+<h1>Import Results</h1>
+
+<div class="info">
+    <p>{{ message }}</p>
+</div>
+
+{% if warnings %}
+<div class="warning">
+    <strong>Warnings:</strong>
+    <ul>
+        {% for w in warnings %}
+            <li>{{ w }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
+<p>
+    <a href="/transactions">View Transactions</a> |
+    <a href="/import">Import Another File</a>
+</p>
+{% endblock %}

--- a/src/money_mapper/api/templates/mappings.html
+++ b/src/money_mapper/api/templates/mappings.html
@@ -23,7 +23,12 @@
 <h2>Create New Mapping</h2>
 <form method="post">
     <input type="text" name="merchant" placeholder="Merchant name" required>
-    <input type="text" name="category" placeholder="Category" required>
+    <input type="text" name="category" list="pfc-categories" placeholder="Category" required>
+    <datalist id="pfc-categories">
+        {% for cat in pfc_categories %}
+            <option value="{{ cat }}">
+        {% endfor %}
+    </datalist>
     <input type="text" name="source" placeholder="Scope (public/private)" required>
     <button type="submit">Create Mapping</button>
 </form>

--- a/src/money_mapper/community_flow.py
+++ b/src/money_mapper/community_flow.py
@@ -154,17 +154,18 @@ def create_contribution_branch(branch_name: str) -> bool:
         return False
 
 
-def create_community_pr(template: dict[str, str]) -> str | None:
+def create_community_pr(template: dict[str, str]) -> tuple[str | None, str]:
     """Create a GitHub PR for the merchant mapping contribution.
 
     Args:
         template: PR template from generate_pr_template()
 
     Returns:
-        str: URL of created PR, or None if creation failed
+        tuple: (pr_url, error_output) where pr_url is the URL of the created PR or None
+            if creation failed, and error_output is the captured error text on failure.
     """
     if not check_gh_cli_available():
-        return None
+        return None, "GitHub CLI (gh) is not installed"
 
     try:
         result = subprocess.run(  # nosec B603, B607
@@ -179,21 +180,26 @@ def create_community_pr(template: dict[str, str]) -> str | None:
                 "--label",
                 "community-contribution",
             ],
-            check=True,
             capture_output=True,
             text=True,
             timeout=15,
         )
 
+        if result.returncode != 0:
+            error_output = (result.stderr or result.stdout or "unknown error").strip()
+            return None, error_output
+
         # Extract PR URL from output
         pr_url = result.stdout.strip()
         # Validate URL format before returning
         if pr_url and pr_url.startswith("https://github.com/"):
-            return pr_url
-        return None
+            return pr_url, ""
+        return None, f"Unexpected output from gh pr create: {pr_url!r}"
 
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        return None
+    except subprocess.TimeoutExpired:
+        return None, "gh pr create timed out after 15 seconds"
+    except (FileNotFoundError, OSError) as exc:
+        return None, str(exc)
 
 
 def submit_community_contribution(merchant: str, category: str, source: str) -> dict[str, Any]:
@@ -226,7 +232,23 @@ def submit_community_contribution(merchant: str, category: str, source: str) -> 
         return {
             "success": False,
             "validation": validation,
-            "error": "GitHub CLI (gh) not available. Install with: brew install gh",
+            "error": (
+                "GitHub CLI (gh) is not installed. Install it:\n"
+                "  Windows: winget install --id GitHub.cli\n"
+                "  macOS:   brew install gh\n"
+                "  Linux:   See https://github.com/cli/cli/blob/trunk/docs/install_linux.md\n"
+                "After installing, run: gh auth login"
+            ),
+        }
+
+    auth_result = subprocess.run(  # nosec B603, B607
+        ["gh", "auth", "status"], capture_output=True, text=True
+    )
+    if auth_result.returncode != 0:
+        return {
+            "success": False,
+            "validation": validation,
+            "error": "GitHub CLI is installed but not authenticated. Run: gh auth login",
         }
 
     template = generate_pr_template(merchant, category, source)
@@ -239,13 +261,13 @@ def submit_community_contribution(merchant: str, category: str, source: str) -> 
             "error": f"Failed to create branch: {template['branch']}",
         }
 
-    pr_url = create_community_pr(template)
+    pr_url, error_output = create_community_pr(template)
 
     if not pr_url:
         return {
             "success": False,
             "validation": validation,
-            "error": "Failed to create GitHub PR",
+            "error": f"Failed to create GitHub PR: {error_output}",
         }
 
     return {

--- a/src/money_mapper/transaction_enricher.py
+++ b/src/money_mapper/transaction_enricher.py
@@ -183,6 +183,13 @@ def get_pattern_matchers(private_mappings: dict, public_mappings: dict):
     return _private_matcher, _public_matcher
 
 
+def clear_pattern_cache():
+    """Clear cached pattern matchers so new mappings take effect."""
+    global _private_matcher, _public_matcher
+    _private_matcher = None
+    _public_matcher = None
+
+
 def _enrich_transaction_worker(args: tuple) -> dict:
     """
     Worker function for multiprocessing enrichment.

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -211,6 +211,19 @@ class TestImportRoute:
         assert response.status_code in [400, 500]
         assert "could not detect" in response.text.lower() or "format" in response.text.lower()
 
+    def test_import_success_returns_html_with_links(self, client):
+        """Successful import should return HTML with navigation links."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write("Date,Description,Debit,Credit\n2026-01-15,Starbucks,5.50,\n")
+            f.flush()
+            with open(f.name, "rb") as csv_file:
+                response = client.post("/import", files={"file": csv_file})
+        if response.status_code in [200, 207]:
+            assert "view transactions" in response.text.lower() or "/transactions" in response.text
+            assert "import another" in response.text.lower() or "/import" in response.text
+
 
 class TestMappingsRoute:
     """Test /mappings GET/POST endpoints."""
@@ -248,6 +261,14 @@ class TestMappingsRoute:
         response = client.get("/mappings")
         # Should at least load without error
         assert response.status_code == 200
+
+    def test_mappings_has_category_datalist(self, client):
+        """Mappings page should have a datalist with PFC categories."""
+        response = client.get("/mappings")
+        assert "datalist" in response.text.lower()
+        assert "pfc-categories" in response.text
+        # Should have at least some PFC categories
+        assert "FOOD_AND_DRINK" in response.text
 
     def test_post_invalid_category_returns_400(self, client):
         """POST /mappings with invalid PFC category returns 400 with suggestions."""

--- a/tests/test_community_flow.py
+++ b/tests/test_community_flow.py
@@ -202,53 +202,72 @@ class TestCommunityPRCreation:
     def test_create_pr_success(self, mock_available, mock_run):
         """create_community_pr() should successfully create PR."""
         mock_available.return_value = True
-        mock_run.return_value = MagicMock(stdout="https://github.com/user/repo/pull/1\n")
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="https://github.com/user/repo/pull/1\n", stderr=""
+        )
         template = {"title": "Test", "body": "Body"}
-        result = create_community_pr(template)
-        assert result is not None
+        pr_url, error_output = create_community_pr(template)
+        assert pr_url is not None
+        assert error_output == ""
 
     @patch("money_mapper.community_flow.subprocess.run")
     @patch("money_mapper.community_flow.check_gh_cli_available")
     def test_create_pr_with_full_template(self, mock_available, mock_run):
         """Should create PR with complete template data."""
         mock_available.return_value = True
-        mock_run.return_value = MagicMock(stdout="https://github.com/user/repo/pull/2\n")
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="https://github.com/user/repo/pull/2\n", stderr=""
+        )
         template = generate_pr_template("Test", "Cat", "src")
-        result = create_community_pr(template)
-        assert result is not None
+        pr_url, error_output = create_community_pr(template)
+        assert pr_url is not None
 
     @patch("money_mapper.community_flow.subprocess.run")
     @patch("money_mapper.community_flow.check_gh_cli_available")
     def test_create_pr_returns_pr_url(self, mock_available, mock_run):
         """Should return the created PR's URL."""
         mock_available.return_value = True
-        mock_run.return_value = MagicMock(stdout="https://github.com/user/repo/pull/123\n")
-        result = create_community_pr({"title": "T", "body": "B"})
-        assert result is not None
-        assert result.startswith("https://github.com/")
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="https://github.com/user/repo/pull/123\n", stderr=""
+        )
+        pr_url, error_output = create_community_pr({"title": "T", "body": "B"})
+        assert pr_url is not None
+        assert pr_url.startswith("https://github.com/")
 
     @patch("money_mapper.community_flow.check_gh_cli_available")
     def test_create_pr_handles_missing_gh(self, mock_available):
-        """Should return None if gh CLI not available."""
+        """Should return (None, error) if gh CLI not available."""
         mock_available.return_value = False
-        result = create_community_pr({"title": "T", "body": "B"})
-        assert result is None
+        pr_url, error_output = create_community_pr({"title": "T", "body": "B"})
+        assert pr_url is None
+        assert "not installed" in error_output
 
     @patch("money_mapper.community_flow.subprocess.run")
     @patch("money_mapper.community_flow.check_gh_cli_available")
-    def test_create_pr_handles_git_error(self, mock_available, mock_run):
-        """Should handle git command failures gracefully."""
+    def test_create_pr_handles_nonzero_returncode(self, mock_available, mock_run):
+        """Should return (None, error_text) when gh returns non-zero exit code."""
         mock_available.return_value = True
-        mock_run.side_effect = subprocess.CalledProcessError(1, "gh")
-        result = create_community_pr({"title": "T", "body": "B"})
-        assert result is None
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="authentication required")
+        pr_url, error_output = create_community_pr({"title": "T", "body": "B"})
+        assert pr_url is None
+        assert "authentication required" in error_output
+
+    @patch("money_mapper.community_flow.subprocess.run")
+    @patch("money_mapper.community_flow.check_gh_cli_available")
+    def test_create_pr_handles_os_error(self, mock_available, mock_run):
+        """Should return (None, error_text) on OS-level errors."""
+        mock_available.return_value = True
+        mock_run.side_effect = OSError("process failed")
+        pr_url, error_output = create_community_pr({"title": "T", "body": "B"})
+        assert pr_url is None
+        assert error_output != ""
 
     @patch("money_mapper.community_flow.subprocess.run")
     @patch("money_mapper.community_flow.check_gh_cli_available")
     def test_create_pr_sets_labels(self, mock_available, mock_run):
         """Should set 'community-contribution' label on PR."""
         mock_available.return_value = True
-        mock_run.return_value = MagicMock(stdout="https://pr\n")
+        mock_run.return_value = MagicMock(returncode=0, stdout="https://pr\n", stderr="")
         create_community_pr({"title": "T", "body": "B"})
         # Verify label was included in call
         call_args = mock_run.call_args[0][0]
@@ -293,14 +312,18 @@ class TestEndToEndFlow:
 
     @patch("money_mapper.community_flow.create_community_pr")
     @patch("money_mapper.community_flow.create_contribution_branch")
+    @patch("money_mapper.community_flow.subprocess.run")
     @patch("money_mapper.community_flow.check_gh_cli_available")
     @patch("money_mapper.community_flow.audit_merchant_name")
-    def test_full_workflow_happy_path(self, mock_audit, mock_gh, mock_branch, mock_pr):
+    def test_full_workflow_happy_path(
+        self, mock_audit, mock_gh, mock_subproc, mock_branch, mock_pr
+    ):
         """Complete flow from validation to PR creation should work."""
         mock_audit.return_value = {"score": 0, "findings": [], "risk_level": "low"}
         mock_gh.return_value = True
+        mock_subproc.return_value = MagicMock(returncode=0)
         mock_branch.return_value = True
-        mock_pr.return_value = "https://pr"
+        mock_pr.return_value = ("https://pr", "")
 
         result = submit_community_contribution("Test", "Category", "source")
         assert result["success"] is True
@@ -325,28 +348,78 @@ class TestEndToEndFlow:
         result = submit_community_contribution("Test", "Cat", "src")
         assert result["success"] is False
 
-    @patch("money_mapper.community_flow.create_community_pr")
-    @patch("money_mapper.community_flow.create_contribution_branch")
     @patch("money_mapper.community_flow.check_gh_cli_available")
     @patch("money_mapper.community_flow.audit_merchant_name")
-    def test_workflow_creates_feature_branch(self, mock_audit, mock_gh, mock_branch, mock_pr):
+    def test_workflow_requires_gh_auth(self, mock_audit, mock_gh):
+        """Complete flow should fail when gh CLI is not authenticated."""
+        mock_audit.return_value = {"score": 0, "findings": [], "risk_level": "low"}
+        mock_gh.return_value = True
+        with patch("money_mapper.community_flow.subprocess.run") as mock_subproc:
+            mock_subproc.return_value = MagicMock(returncode=1)
+            result = submit_community_contribution("Test", "Cat", "src")
+        assert result["success"] is False
+        assert "gh auth login" in result["error"]
+
+    @patch("money_mapper.community_flow.create_community_pr")
+    @patch("money_mapper.community_flow.create_contribution_branch")
+    @patch("money_mapper.community_flow.subprocess.run")
+    @patch("money_mapper.community_flow.check_gh_cli_available")
+    @patch("money_mapper.community_flow.audit_merchant_name")
+    def test_workflow_creates_feature_branch(
+        self, mock_audit, mock_gh, mock_subproc, mock_branch, mock_pr
+    ):
         """Workflow should create feature branch with proper name."""
         mock_audit.return_value = {"score": 0, "findings": [], "risk_level": "low"}
         mock_gh.return_value = True
+        mock_subproc.return_value = MagicMock(returncode=0)
         mock_branch.return_value = True
-        mock_pr.return_value = "https://pr"
+        mock_pr.return_value = ("https://pr", "")
         submit_community_contribution("Test", "Cat", "src")
         mock_branch.assert_called_once()
 
     @patch("money_mapper.community_flow.create_community_pr")
     @patch("money_mapper.community_flow.create_contribution_branch")
+    @patch("money_mapper.community_flow.subprocess.run")
     @patch("money_mapper.community_flow.check_gh_cli_available")
     @patch("money_mapper.community_flow.audit_merchant_name")
-    def test_workflow_generates_proper_pr(self, mock_audit, mock_gh, mock_branch, mock_pr):
+    def test_workflow_generates_proper_pr(
+        self, mock_audit, mock_gh, mock_subproc, mock_branch, mock_pr
+    ):
         """Final PR should have all required information."""
         mock_audit.return_value = {"score": 0, "findings": [], "risk_level": "low"}
         mock_gh.return_value = True
+        mock_subproc.return_value = MagicMock(returncode=0)
         mock_branch.return_value = True
-        mock_pr.return_value = "https://github.com/user/repo/pull/1"
+        mock_pr.return_value = ("https://github.com/user/repo/pull/1", "")
         result = submit_community_contribution("TestMerchant", "Category", "source")
         assert result["pr_url"] == "https://github.com/user/repo/pull/1"
+
+    @patch("money_mapper.community_flow.create_community_pr")
+    @patch("money_mapper.community_flow.create_contribution_branch")
+    @patch("money_mapper.community_flow.subprocess.run")
+    @patch("money_mapper.community_flow.check_gh_cli_available")
+    @patch("money_mapper.community_flow.audit_merchant_name")
+    def test_workflow_includes_pr_error_on_failure(
+        self, mock_audit, mock_gh, mock_subproc, mock_branch, mock_pr
+    ):
+        """Error message from PR creation should be surfaced to the caller."""
+        mock_audit.return_value = {"score": 0, "findings": [], "risk_level": "low"}
+        mock_gh.return_value = True
+        mock_subproc.return_value = MagicMock(returncode=0)
+        mock_branch.return_value = True
+        mock_pr.return_value = (None, "repository not found")
+        result = submit_community_contribution("TestMerchant", "Category", "source")
+        assert result["success"] is False
+        assert "repository not found" in result["error"]
+
+    @patch("money_mapper.community_flow.check_gh_cli_available")
+    @patch("money_mapper.community_flow.audit_merchant_name")
+    def test_workflow_gh_missing_error_message_multiplatform(self, mock_audit, mock_gh):
+        """Error when gh is missing should cover all three platforms."""
+        mock_audit.return_value = {"score": 0, "findings": [], "risk_level": "low"}
+        mock_gh.return_value = False
+        result = submit_community_contribution("Test", "Cat", "src")
+        assert result["success"] is False
+        assert "winget" in result["error"]
+        assert "brew" in result["error"]
+        assert "linux" in result["error"].lower()

--- a/tests/test_transaction_enricher.py
+++ b/tests/test_transaction_enricher.py
@@ -1395,6 +1395,23 @@ class TestGetPatternMatchers:
         te._public_matcher = None
 
 
+class TestClearPatternCache:
+    """Test pattern matcher cache invalidation."""
+
+    def test_clear_resets_both_matchers(self):
+        """clear_pattern_cache should reset both matchers to None."""
+        import money_mapper.transaction_enricher as te
+
+        # Set them to non-None values
+        te._private_matcher = "fake_private"
+        te._public_matcher = "fake_public"
+
+        te.clear_pattern_cache()
+
+        assert te._private_matcher is None
+        assert te._public_matcher is None
+
+
 class TestEnrichTransactionWorker:
     """Tests for the multiprocessing worker function."""
 


### PR DESCRIPTION
## Summary

Four UX improvements from the Group E spec:

- **E7: Cache invalidation** - Added `clear_pattern_cache()` to transaction_enricher.py, called from POST /mappings after writing new mappings. New mappings now take effect without server restart.
- **E9: Category datalist** - Mappings form category input now has a `<datalist>` autocomplete populated with all 104 PFC subcategories from plaid_categories.toml. Users type and get filtered suggestions.
- **E6: Contribute error messages** - Community contribution errors now include platform-specific install instructions (Windows/macOS/Linux), authentication status check (`gh auth status`), and actual subprocess error output.
- **E2: Import result page** - Successful import now shows an HTML page (via `import_result.html` template) with summary, warnings list, and navigation links ("View Transactions" / "Import Another File") instead of raw text.

## Files Changed

- `src/money_mapper/transaction_enricher.py` - E7: `clear_pattern_cache()` function
- `src/money_mapper/api/server.py` - E7: call cache clear on mapping write; E9: load PFC categories for template; E2: render import result template
- `src/money_mapper/api/templates/import_result.html` - E2: new template
- `src/money_mapper/api/templates/mappings.html` - E9: datalist for category input
- `src/money_mapper/community_flow.py` - E6: improved error messages + auth check
- `tests/test_api_server.py` - New tests for datalist, import result page
- `tests/test_transaction_enricher.py` - Test for cache clear
- `tests/test_community_flow.py` - Tests for improved error messages

## Test Coverage

All fixes verified by automated tests (1143 passed, 0 failures) and browser verification:

- Mappings page HTML contains datalist with PFC categories
- Import result page renders with summary and navigation links
- Cache invalidation resets both pattern matchers
- Community flow errors include actionable guidance