### PR TITLE
Feature: advanced search on transactions page

### DIFF
--- a/src/money_mapper/api/server.py
+++ b/src/money_mapper/api/server.py
@@ -144,6 +144,18 @@ def _filter_transactions(
     if max_amount is not None:
         result = [t for t in result if abs(float(t.get("amount", 0))) <= max_amount]
 
+    if sort:
+        sort_key_funcs = {
+            "date": lambda t: t.get("date", ""),
+            "merchant": lambda t: t.get("merchant_name", ""),
+            "amount": lambda t: abs(float(t.get("amount", 0))),
+            "category": lambda t: t.get("category", ""),
+        }
+        key_func = sort_key_funcs.get(sort)
+        if key_func is not None:
+            reverse = order == "desc"
+            result = sorted(result, key=key_func, reverse=reverse)
+
     return result
 
 

--- a/src/money_mapper/api/server.py
+++ b/src/money_mapper/api/server.py
@@ -278,11 +278,23 @@ def create_app(data_dir: str | None = None) -> FastAPI:
         return HTMLResponse(f"Updated transaction {safe_id} to {safe_category}", status_code=200)
 
     @app.get("/transactions/export", response_class=HTMLResponse)
-    async def export_transactions(q: str | None = None) -> HTMLResponse:
-        """Export transactions as CSV, optionally filtered by search query.
+    async def export_transactions(
+        q: str | None = None,
+        sort: str | None = None,
+        order: str | None = None,
+        min_amount: str | None = None,
+        max_amount: str | None = None,
+        categories: str | None = None,
+    ) -> HTMLResponse:
+        """Export transactions as CSV, honoring the same filters as /api/transactions.
 
         Args:
             q: Optional search query to filter transactions across all fields.
+            sort: Column to sort by. One of: "date", "merchant", "amount", "category".
+            order: "asc" or "desc". Defaults to "asc" when sort is set.
+            min_amount: Include only transactions where abs(amount) >= min_amount.
+            max_amount: Include only transactions where abs(amount) <= max_amount.
+            categories: Comma-separated list of categories to include.
 
         Returns:
             HTMLResponse: CSV data with Content-Disposition header for download.
@@ -291,7 +303,21 @@ def create_app(data_dir: str | None = None) -> FastAPI:
 
         transactions = _load_enriched_transactions(enriched_path)
 
-        transactions = _filter_transactions(transactions, q=q)
+        min_val = _parse_float_param(min_amount)
+        max_val = _parse_float_param(max_amount)
+        category_list = (
+            [c.strip() for c in categories.split(",") if c.strip()] if categories else None
+        )
+
+        transactions = _filter_transactions(
+            transactions,
+            q=q,
+            categories=category_list,
+            min_amount=min_val,
+            max_amount=max_val,
+            sort=sort,
+            order=order,
+        )
 
         csv_data = build_csv_export(transactions)
         return HTMLResponse(

--- a/src/money_mapper/api/server.py
+++ b/src/money_mapper/api/server.py
@@ -95,6 +95,48 @@ def _compute_spending_by_category(transactions: list[dict]) -> dict:
     }
 
 
+def _filter_transactions(
+    txns: list,
+    q: str | None = None,
+    categories: list | None = None,
+    min_amount: float | None = None,
+    max_amount: float | None = None,
+    sort: str | None = None,
+    order: str | None = None,
+) -> list:
+    """Apply text search, category filter, amount range filter, and sort.
+
+    Args:
+        txns: List of transaction dicts.
+        q: Case-insensitive substring search across merchant_name, description, category, date, amount.
+        categories: List of category values; include transactions whose category matches any (case-insensitive).
+        min_amount: Include only transactions where abs(amount) >= min_amount.
+        max_amount: Include only transactions where abs(amount) <= max_amount.
+        sort: Column to sort by. One of: "date", "merchant", "amount", "category". Unknown values ignored.
+        order: "asc" or "desc". Defaults to "asc" when sort is set.
+
+    Returns:
+        Filtered and sorted list of transactions.
+    """
+    result = txns
+
+    if q:
+        query = q.lower()
+        result = [
+            t
+            for t in result
+            if (
+                query in t.get("merchant_name", "").lower()
+                or query in t.get("description", "").lower()
+                or query in t.get("category", "").lower()
+                or query in t.get("date", "").lower()
+                or query in str(t.get("amount", ""))
+            )
+        ]
+
+    return result
+
+
 def create_app(data_dir: str | None = None) -> FastAPI:
     """Create and configure FastAPI application.
 
@@ -217,19 +259,7 @@ def create_app(data_dir: str | None = None) -> FastAPI:
 
         transactions = _load_enriched_transactions(enriched_path)
 
-        if q:
-            query = q.lower()
-            transactions = [
-                t
-                for t in transactions
-                if (
-                    query in t.get("merchant_name", "").lower()
-                    or query in t.get("description", "").lower()
-                    or query in t.get("category", "").lower()
-                    or query in t.get("date", "").lower()
-                    or query in str(t.get("amount", ""))
-                )
-            ]
+        transactions = _filter_transactions(transactions, q=q)
 
         csv_data = build_csv_export(transactions)
         return HTMLResponse(
@@ -536,19 +566,7 @@ def create_app(data_dir: str | None = None) -> FastAPI:
         txns = _load_enriched_transactions(enriched_path)
 
         # Apply search filter
-        if q:
-            query = q.lower()
-            txns = [
-                t
-                for t in txns
-                if (
-                    query in t.get("merchant_name", "").lower()
-                    or query in t.get("description", "").lower()
-                    or query in t.get("category", "").lower()
-                    or query in t.get("date", "").lower()
-                    or query in str(t.get("amount", ""))
-                )
-            ]
+        txns = _filter_transactions(txns, q=q)
 
         total = len(txns)
 

--- a/src/money_mapper/api/server.py
+++ b/src/money_mapper/api/server.py
@@ -134,6 +134,10 @@ def _filter_transactions(
             )
         ]
 
+    if categories:
+        category_set = {c.lower() for c in categories}
+        result = [t for t in result if t.get("category", "").lower() in category_set]
+
     if min_amount is not None:
         result = [t for t in result if abs(float(t.get("amount", 0))) >= min_amount]
 

--- a/src/money_mapper/api/server.py
+++ b/src/money_mapper/api/server.py
@@ -134,6 +134,12 @@ def _filter_transactions(
             )
         ]
 
+    if min_amount is not None:
+        result = [t for t in result if abs(float(t.get("amount", 0))) >= min_amount]
+
+    if max_amount is not None:
+        result = [t for t in result if abs(float(t.get("amount", 0))) <= max_amount]
+
     return result
 
 

--- a/src/money_mapper/api/server.py
+++ b/src/money_mapper/api/server.py
@@ -95,6 +95,16 @@ def _compute_spending_by_category(transactions: list[dict]) -> dict:
     }
 
 
+def _parse_float_param(val: str | None) -> float | None:
+    """Parse a query-string param as float. Return None if invalid or missing."""
+    if val is None or val == "":
+        return None
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None
+
+
 def _filter_transactions(
     txns: list,
     q: str | None = None,
@@ -574,28 +584,48 @@ def create_app(data_dir: str | None = None) -> FastAPI:
         offset: int = 0,
         limit: int = 50,
         q: str | None = None,
+        sort: str | None = None,
+        order: str | None = None,
+        min_amount: str | None = None,
+        max_amount: str | None = None,
+        categories: str | None = None,
     ) -> JSONResponse:
-        """Paginated JSON API for transactions with search.
+        """Paginated JSON API for transactions with search, filter, and sort.
 
         Args:
             offset: Number of transactions to skip.
             limit: Maximum number of transactions to return.
             q: Optional search query across all fields.
+            sort: Column to sort by (date, merchant, amount, category).
+            order: Sort order (asc, desc).
+            min_amount: Minimum absolute amount filter.
+            max_amount: Maximum absolute amount filter.
+            categories: Comma-separated list of categories to filter by.
 
         Returns:
             JSONResponse: Paginated transaction data with total, offset, limit, has_more.
         """
         txns = _load_enriched_transactions(enriched_path)
 
-        # Apply search filter
-        txns = _filter_transactions(txns, q=q)
+        min_val = _parse_float_param(min_amount)
+        max_val = _parse_float_param(max_amount)
+        category_list = (
+            [c.strip() for c in categories.split(",") if c.strip()] if categories else None
+        )
+
+        txns = _filter_transactions(
+            txns,
+            q=q,
+            categories=category_list,
+            min_amount=min_val,
+            max_amount=max_val,
+            sort=sort,
+            order=order,
+        )
 
         total = len(txns)
-
-        # Apply pagination
         paginated = txns[offset : offset + limit]
 
-        # Format for response
         formatted = [
             {
                 "id": offset + i,

--- a/src/money_mapper/api/server.py
+++ b/src/money_mapper/api/server.py
@@ -19,6 +19,31 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, PackageLoader, select_autoescape
 
+_pfc_categories_cache: list | None = None
+
+
+def _load_pfc_categories(base_dir: str) -> list:
+    """Load and cache PFC detailed categories from plaid_categories.toml."""
+    global _pfc_categories_cache
+    if _pfc_categories_cache is not None:
+        return _pfc_categories_cache
+
+    plaid_path = os.path.join(base_dir, "config", "plaid_categories.toml")
+    categories: list = []
+    try:
+        with open(plaid_path, "rb") as f:
+            plaid_data = tomllib.load(f)
+        for primary_val in plaid_data.values():
+            if isinstance(primary_val, dict):
+                for detailed_key in primary_val:
+                    categories.append(detailed_key)
+        categories.sort()
+    except (OSError, tomllib.TOMLDecodeError):
+        pass
+
+    _pfc_categories_cache = categories
+    return categories
+
 
 def _load_enriched_transactions(file_path: str) -> list[dict]:
     """Load enriched transactions from JSON file.
@@ -673,6 +698,12 @@ def create_app(data_dir: str | None = None) -> FastAPI:
                 "transactions": formatted,
             }
         )
+
+    # ===== Categories API Route =====
+    @app.get("/api/categories")
+    async def categories_api() -> JSONResponse:
+        """Return the list of PFC detailed categories."""
+        return JSONResponse({"categories": _load_pfc_categories(base_dir)})
 
     # Mount static files if they exist
     static_path = Path(__file__).parent / "static"

--- a/src/money_mapper/api/static/js/transactions.js
+++ b/src/money_mapper/api/static/js/transactions.js
@@ -1,8 +1,5 @@
 /**
- * Transactions page: infinite scroll and search.
- *
- * Loads additional transactions as the user scrolls near the bottom of the page.
- * Provides debounced search that queries the /api/transactions endpoint.
+ * Transactions page: infinite scroll, search, sort, and advanced filters.
  */
 
 (function () {
@@ -16,6 +13,13 @@
     var searchQuery = "";
     var debounceTimer = null;
 
+    var sortColumn = null;
+    var sortOrder = null;
+    var minAmount = "";
+    var maxAmount = "";
+    var selectedCategories = [];
+    var filtersVisible = false;
+
     // --- DOM references ---
     var tbody = document.querySelector("#transactions-table tbody");
     var searchInput = document.querySelector("#transaction-search");
@@ -25,25 +29,33 @@
     var exportLink = document.querySelector("#export-link");
     var exportAnchor = exportLink ? exportLink.querySelector("a") : null;
 
+    var filtersToggle = document.querySelector("#filters-toggle");
+    var filtersPanel = document.querySelector("#filters-panel");
+    var filtersActiveIndicator = document.querySelector("#filters-active-indicator");
+    var minAmountInput = document.querySelector("#filter-min-amount");
+    var maxAmountInput = document.querySelector("#filter-max-amount");
+    var categoryInput = document.querySelector("#filter-category-input");
+    var categoryDatalist = document.querySelector("#category-datalist");
+    var selectedCategoriesDiv = document.querySelector("#selected-categories");
+    var applyFiltersBtn = document.querySelector("#apply-filters");
+    var clearFiltersBtn = document.querySelector("#clear-filters");
+    var sortableHeaders = document.querySelectorAll("th.sortable");
+
     if (!tbody || !searchInput) {
-        return; // Not on the transactions page
+        return;
     }
 
-    // Read initial state from the table's data attributes
     var table = document.querySelector("#transactions-table");
     currentTotal = parseInt(table.getAttribute("data-total") || "0", 10);
     currentOffset = tbody.querySelectorAll("tr:not(#loading-row)").length;
     hasMore = currentOffset < currentTotal;
-
     updateCount();
 
     // --- Infinite scroll ---
     window.addEventListener("scroll", function () {
         if (loading || !hasMore) return;
-
         var scrollBottom = window.innerHeight + window.scrollY;
         var pageHeight = document.documentElement.scrollHeight;
-
         if (pageHeight - scrollBottom < 200) {
             loadMore();
         }
@@ -66,17 +78,161 @@
         });
     }
 
+    // --- Filter panel toggle ---
+    if (filtersToggle && filtersPanel) {
+        filtersToggle.addEventListener("click", function () {
+            filtersVisible = !filtersVisible;
+            filtersPanel.style.display = filtersVisible ? "" : "none";
+            filtersToggle.textContent = filtersVisible ? "Hide Filters" : "Show Filters";
+            updateFiltersActiveIndicator();
+        });
+    }
+
+    // --- Load categories for type-ahead ---
+    fetch("/api/categories")
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            if (!categoryDatalist || !data.categories) return;
+            for (var i = 0; i < data.categories.length; i++) {
+                var opt = document.createElement("option");
+                opt.value = data.categories[i];
+                categoryDatalist.appendChild(opt);
+            }
+        })
+        .catch(function () { });
+
+    // --- Category selection (type-ahead add) ---
+    if (categoryInput) {
+        categoryInput.addEventListener("change", function () {
+            var val = categoryInput.value.trim();
+            if (!val) return;
+            if (selectedCategories.indexOf(val) === -1) {
+                selectedCategories.push(val);
+                renderSelectedCategories();
+            }
+            categoryInput.value = "";
+        });
+    }
+
+    function renderSelectedCategories() {
+        if (!selectedCategoriesDiv) return;
+        while (selectedCategoriesDiv.firstChild) {
+            selectedCategoriesDiv.removeChild(selectedCategoriesDiv.firstChild);
+        }
+        for (var i = 0; i < selectedCategories.length; i++) {
+            (function (cat) {
+                var tag = document.createElement("span");
+                tag.style.cssText = "display:inline-block;background:#2c3e50;color:#fff;padding:2px 8px;margin:2px;border-radius:3px;font-size:0.85em";
+                tag.textContent = cat + " ";
+                var x = document.createElement("button");
+                x.type = "button";
+                x.textContent = "x";
+                x.style.cssText = "background:none;border:none;color:#fff;cursor:pointer;padding:0 0 0 4px";
+                x.addEventListener("click", function () {
+                    var idx = selectedCategories.indexOf(cat);
+                    if (idx !== -1) {
+                        selectedCategories.splice(idx, 1);
+                        renderSelectedCategories();
+                        resetAndLoad();
+                    }
+                });
+                tag.appendChild(x);
+                selectedCategoriesDiv.appendChild(tag);
+            })(selectedCategories[i]);
+        }
+    }
+
+    // --- Apply / Clear Filters ---
+    if (applyFiltersBtn) {
+        applyFiltersBtn.addEventListener("click", function () {
+            var minVal = minAmountInput ? minAmountInput.value.trim() : "";
+            var maxVal = maxAmountInput ? maxAmountInput.value.trim() : "";
+            if (minVal && isNaN(parseFloat(minVal))) {
+                minAmountInput.value = "";
+                minVal = "";
+            }
+            if (maxVal && isNaN(parseFloat(maxVal))) {
+                maxAmountInput.value = "";
+                maxVal = "";
+            }
+            minAmount = minVal;
+            maxAmount = maxVal;
+            resetAndLoad();
+        });
+    }
+
+    if (clearFiltersBtn) {
+        clearFiltersBtn.addEventListener("click", function () {
+            minAmount = "";
+            maxAmount = "";
+            selectedCategories = [];
+            if (minAmountInput) minAmountInput.value = "";
+            if (maxAmountInput) maxAmountInput.value = "";
+            if (categoryInput) categoryInput.value = "";
+            renderSelectedCategories();
+            resetAndLoad();
+        });
+    }
+
+    // --- Sort header clicks ---
+    for (var i = 0; i < sortableHeaders.length; i++) {
+        (function (th) {
+            th.addEventListener("click", function () {
+                var col = th.getAttribute("data-column");
+                if (sortColumn !== col) {
+                    sortColumn = col;
+                    sortOrder = "asc";
+                } else if (sortOrder === "asc") {
+                    sortOrder = "desc";
+                } else {
+                    sortColumn = null;
+                    sortOrder = null;
+                }
+                renderSortIndicators();
+                resetAndLoad();
+            });
+        })(sortableHeaders[i]);
+    }
+
+    function renderSortIndicators() {
+        for (var j = 0; j < sortableHeaders.length; j++) {
+            var th = sortableHeaders[j];
+            var ind = th.querySelector(".sort-indicator");
+            if (!ind) continue;
+            if (th.getAttribute("data-column") === sortColumn) {
+                ind.textContent = sortOrder === "asc" ? " [A]" : " [D]";
+            } else {
+                ind.textContent = "";
+            }
+        }
+    }
+
     // --- Core functions ---
+    function buildQueryString(includePagination) {
+        var parts = [];
+        if (includePagination) {
+            parts.push("offset=" + currentOffset);
+            parts.push("limit=50");
+        }
+        if (searchQuery) parts.push("q=" + encodeURIComponent(searchQuery));
+        if (sortColumn) {
+            parts.push("sort=" + encodeURIComponent(sortColumn));
+            parts.push("order=" + encodeURIComponent(sortOrder || "asc"));
+        }
+        if (minAmount) parts.push("min_amount=" + encodeURIComponent(minAmount));
+        if (maxAmount) parts.push("max_amount=" + encodeURIComponent(maxAmount));
+        if (selectedCategories.length > 0) {
+            parts.push("categories=" + encodeURIComponent(selectedCategories.join(",")));
+        }
+        return parts.join("&");
+    }
 
     function loadMore() {
         if (loading || !hasMore) return;
         loading = true;
         showLoading(true);
 
-        var url = "/api/transactions?offset=" + currentOffset + "&limit=50";
-        if (searchQuery) {
-            url += "&q=" + encodeURIComponent(searchQuery);
-        }
+        var url = "/api/transactions?" + buildQueryString(true);
 
         fetch(url)
             .then(function (response) { return response.json(); })
@@ -87,6 +243,7 @@
                 hasMore = data.has_more;
                 updateCount();
                 updateExportLink();
+                updateFiltersActiveIndicator();
                 loading = false;
                 showLoading(false);
             })
@@ -97,12 +254,10 @@
     }
 
     function resetAndLoad() {
-        // Clear existing rows (except loading row)
         var rows = tbody.querySelectorAll("tr:not(#loading-row)");
         for (var i = 0; i < rows.length; i++) {
             rows[i].remove();
         }
-
         currentOffset = 0;
         hasMore = true;
         loading = false;
@@ -125,7 +280,6 @@
             tdAmount.textContent = "$" + txn.amount.toFixed(2);
 
             var tdCategory = document.createElement("td");
-            // Create the inline update form
             var form = document.createElement("form");
             form.method = "post";
             form.action = "/transactions/" + txn.id;
@@ -151,7 +305,6 @@
             tr.appendChild(tdAmount);
             tr.appendChild(tdCategory);
 
-            // Insert before loading row if it exists, otherwise append
             if (loadingRow) {
                 tbody.insertBefore(tr, loadingRow);
             } else {
@@ -173,6 +326,19 @@
         }
     }
 
+    function hasAdvancedFilters() {
+        return minAmount !== "" || maxAmount !== "" || selectedCategories.length > 0;
+    }
+
+    function updateFiltersActiveIndicator() {
+        if (!filtersActiveIndicator) return;
+        if (hasAdvancedFilters() && !filtersVisible) {
+            filtersActiveIndicator.style.display = "";
+        } else {
+            filtersActiveIndicator.style.display = "none";
+        }
+    }
+
     function updateExportLink() {
         if (!exportLink) return;
         if (currentTotal === 0) {
@@ -181,8 +347,9 @@
         }
         exportLink.style.display = "";
         if (exportAnchor) {
-            if (searchQuery) {
-                exportAnchor.href = "/transactions/export?q=" + encodeURIComponent(searchQuery);
+            var qs = buildQueryString(false);
+            if (qs) {
+                exportAnchor.href = "/transactions/export?" + qs;
                 exportAnchor.textContent = "Export filtered results (CSV)";
             } else {
                 exportAnchor.href = "/transactions/export";

--- a/src/money_mapper/api/templates/transactions.html
+++ b/src/money_mapper/api/templates/transactions.html
@@ -12,7 +12,26 @@
 <div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">
     <input type="text" id="transaction-search" placeholder="Search transactions..." style="flex:1">
     <button id="search-clear" type="button">Clear</button>
+    <button id="filters-toggle" type="button">Show Filters</button>
+    <span id="filters-active-indicator" style="display:none;color:#2c3e50;font-size:0.9em">Filters active</span>
 </div>
+
+<div id="filters-panel" style="display:none;border:1px solid #ddd;padding:12px;margin-bottom:12px;background:#f9f9f9">
+    <div style="display:flex;gap:12px;align-items:center;margin-bottom:8px">
+        <label>Min $ <input type="text" id="filter-min-amount" style="width:80px"></label>
+        <label>Max $ <input type="text" id="filter-max-amount" style="width:80px"></label>
+    </div>
+    <div style="margin-bottom:8px">
+        <label>Category
+            <input type="text" id="filter-category-input" list="category-datalist" placeholder="Type to search...">
+        </label>
+        <datalist id="category-datalist"></datalist>
+        <div id="selected-categories" style="margin-top:6px"></div>
+    </div>
+    <button id="apply-filters" type="button">Apply Filters</button>
+    <button id="clear-filters" type="button">Clear Filters</button>
+</div>
+
 <div id="transaction-count" style="color:#666;font-size:0.9em;margin-bottom:12px">
     Showing {{ transactions|length }} of {{ total }} transactions
 </div>
@@ -20,10 +39,10 @@
 <table id="transactions-table" data-total="{{ total }}">
     <thead>
         <tr>
-            <th>Date</th>
-            <th>Merchant</th>
-            <th>Amount</th>
-            <th>Category</th>
+            <th class="sortable" data-column="date" style="cursor:pointer">Date <span class="sort-indicator"></span></th>
+            <th class="sortable" data-column="merchant" style="cursor:pointer">Merchant <span class="sort-indicator"></span></th>
+            <th class="sortable" data-column="amount" style="cursor:pointer">Amount <span class="sort-indicator"></span></th>
+            <th class="sortable" data-column="category" style="cursor:pointer">Category <span class="sort-indicator"></span></th>
         </tr>
     </thead>
     <tbody>

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1112,3 +1112,66 @@ class TestTransactionsExport:
         rows = list(reader)
         assert len(rows) == 1  # Header only
         assert rows[0] == ["date", "merchant", "amount", "category"]
+
+
+class TestFilterTransactionsHelper:
+    """Test the shared _filter_transactions helper."""
+
+    def _sample_txns(self):
+        return [
+            {
+                "merchant_name": "Starbucks",
+                "description": "STARBUCKS 123",
+                "category": "FOOD_AND_DRINK_COFFEE",
+                "date": "2026-01-15",
+                "amount": -5.50,
+            },
+            {
+                "merchant_name": "Shell Gas",
+                "description": "SHELL OIL",
+                "category": "TRANSPORTATION_GAS",
+                "date": "2026-01-16",
+                "amount": -42.00,
+            },
+            {
+                "merchant_name": "Paycheck",
+                "description": "DIRECT DEPOSIT",
+                "category": "INCOME_WAGES",
+                "date": "2026-01-01",
+                "amount": 2500.00,
+            },
+        ]
+
+    def test_no_filters_returns_all(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(
+            txns, q=None, categories=None, min_amount=None, max_amount=None, sort=None, order=None
+        )
+        assert len(result) == 3
+
+    def test_text_search_matches_merchant(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(
+            txns,
+            q="starbucks",
+            categories=None,
+            min_amount=None,
+            max_amount=None,
+            sort=None,
+            order=None,
+        )
+        assert len(result) == 1
+        assert result[0]["merchant_name"] == "Starbucks"
+
+    def test_text_search_matches_amount_string(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(
+            txns, q="42.0", categories=None, min_amount=None, max_amount=None, sort=None, order=None
+        )
+        assert len(result) == 1

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1009,6 +1009,99 @@ class TestTransactionsAPI:
         assert data["has_more"] is False
 
 
+class TestTransactionsAPIAdvancedFilters:
+    """Test new advanced filter params on /api/transactions."""
+
+    @pytest.fixture
+    def client(self, tmp_path):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        (output_dir / "enriched_transactions.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "date": "2026-01-15",
+                        "merchant_name": "Starbucks",
+                        "amount": -5.50,
+                        "category": "FOOD_AND_DRINK_COFFEE",
+                    },
+                    {
+                        "date": "2026-01-16",
+                        "merchant_name": "Shell Gas",
+                        "amount": -42.00,
+                        "category": "TRANSPORTATION_GAS",
+                    },
+                    {
+                        "date": "2026-01-01",
+                        "merchant_name": "Paycheck",
+                        "amount": 2500.00,
+                        "category": "INCOME_WAGES",
+                    },
+                ]
+            )
+        )
+        app = create_app(data_dir=str(tmp_path))
+        return TestClient(app)
+
+    def test_min_amount_param(self, client):
+        response = client.get("/api/transactions?min_amount=10")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+
+    def test_max_amount_param(self, client):
+        response = client.get("/api/transactions?max_amount=50")
+        data = response.json()
+        assert data["total"] == 2
+
+    def test_categories_param_single(self, client):
+        response = client.get("/api/transactions?categories=FOOD_AND_DRINK_COFFEE")
+        data = response.json()
+        assert data["total"] == 1
+        assert data["transactions"][0]["merchant"] == "Starbucks"
+
+    def test_categories_param_multiple(self, client):
+        response = client.get(
+            "/api/transactions?categories=FOOD_AND_DRINK_COFFEE,TRANSPORTATION_GAS"
+        )
+        data = response.json()
+        assert data["total"] == 2
+
+    def test_sort_by_amount_desc(self, client):
+        response = client.get("/api/transactions?sort=amount&order=desc")
+        data = response.json()
+        merchants = [t["merchant"] for t in data["transactions"]]
+        assert merchants == ["Paycheck", "Shell Gas", "Starbucks"]
+
+    def test_sort_by_date_asc(self, client):
+        response = client.get("/api/transactions?sort=date&order=asc")
+        data = response.json()
+        dates = [t["date"] for t in data["transactions"]]
+        assert dates == ["2026-01-01", "2026-01-15", "2026-01-16"]
+
+    def test_invalid_min_amount_ignored(self, client):
+        response = client.get("/api/transactions?min_amount=notanumber")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+
+    def test_unknown_sort_column_ignored(self, client):
+        response = client.get("/api/transactions?sort=bogus")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+
+    def test_all_params_combined(self, client):
+        response = client.get(
+            "/api/transactions?categories=FOOD_AND_DRINK_COFFEE,TRANSPORTATION_GAS"
+            "&max_amount=50&sort=amount&order=desc"
+        )
+        data = response.json()
+        assert data["total"] == 2
+        merchants = [t["merchant"] for t in data["transactions"]]
+        assert merchants == ["Shell Gas", "Starbucks"]
+
+
 class TestBrowserRenderingCSVExport:
     """Test CSV export browser rendering."""
 

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1205,3 +1205,41 @@ class TestFilterTransactionsHelper:
         result = _filter_transactions(txns, min_amount=5.50, max_amount=5.50)
         assert len(result) == 1
         assert result[0]["merchant_name"] == "Starbucks"
+
+    def test_single_category(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, categories=["FOOD_AND_DRINK_COFFEE"])
+        assert len(result) == 1
+        assert result[0]["merchant_name"] == "Starbucks"
+
+    def test_multiple_categories_any_match(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(
+            txns, categories=["FOOD_AND_DRINK_COFFEE", "TRANSPORTATION_GAS"]
+        )
+        assert len(result) == 2
+
+    def test_category_case_insensitive(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, categories=["food_and_drink_coffee"])
+        assert len(result) == 1
+
+    def test_unknown_category_returns_empty(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, categories=["NONEXISTENT"])
+        assert result == []
+
+    def test_empty_categories_list_returns_all(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, categories=[])
+        assert len(result) == 3

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1511,3 +1511,30 @@ class TestExportAdvancedFilters:
         assert "Starbucks" in text
         assert "Shell Gas" in text
         assert "Paycheck" not in text
+
+
+class TestCategoriesAPI:
+    """Test /api/categories JSON endpoint."""
+
+    @pytest.fixture
+    def client(self):
+        app = create_app()
+        return TestClient(app)
+
+    def test_returns_json_with_categories(self, client):
+        response = client.get("/api/categories")
+        assert response.status_code == 200
+        data = response.json()
+        assert "categories" in data
+        assert isinstance(data["categories"], list)
+
+    def test_returns_sorted_list(self, client):
+        response = client.get("/api/categories")
+        data = response.json()
+        if len(data["categories"]) > 1:
+            assert data["categories"] == sorted(data["categories"])
+
+    def test_contains_known_pfc_category(self, client):
+        response = client.get("/api/categories")
+        data = response.json()
+        assert any("FOOD_AND_DRINK" in c for c in data["categories"])

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1175,3 +1175,33 @@ class TestFilterTransactionsHelper:
             txns, q="42.0", categories=None, min_amount=None, max_amount=None, sort=None, order=None
         )
         assert len(result) == 1
+
+    def test_min_amount_only(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, min_amount=10.0)
+        assert len(result) == 2
+
+    def test_max_amount_only(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, max_amount=50.0)
+        assert len(result) == 2
+
+    def test_both_amount_bounds(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, min_amount=10.0, max_amount=100.0)
+        assert len(result) == 1
+        assert result[0]["merchant_name"] == "Shell Gas"
+
+    def test_amount_bounds_inclusive(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, min_amount=5.50, max_amount=5.50)
+        assert len(result) == 1
+        assert result[0]["merchant_name"] == "Starbucks"

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1310,3 +1310,48 @@ class TestFilterTransactionsHelper:
         txns = self._sample_txns()
         result = _filter_transactions(txns, sort=None)
         assert [t["merchant_name"] for t in result] == ["Starbucks", "Shell Gas", "Paycheck"]
+
+    def test_all_filters_combined(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = [
+            {
+                "merchant_name": "Starbucks",
+                "description": "COFFEE A",
+                "category": "FOOD_AND_DRINK_COFFEE",
+                "date": "2026-01-15",
+                "amount": -5.50,
+            },
+            {
+                "merchant_name": "Starbucks",
+                "description": "COFFEE B",
+                "category": "FOOD_AND_DRINK_COFFEE",
+                "date": "2026-01-10",
+                "amount": -8.00,
+            },
+            {
+                "merchant_name": "Shell Gas",
+                "description": "GAS",
+                "category": "TRANSPORTATION_GAS",
+                "date": "2026-01-16",
+                "amount": -42.00,
+            },
+            {
+                "merchant_name": "Starbucks",
+                "description": "COFFEE C",
+                "category": "FOOD_AND_DRINK_COFFEE",
+                "date": "2026-01-20",
+                "amount": -100.00,
+            },
+        ]
+        result = _filter_transactions(
+            txns,
+            q="starbucks",
+            categories=["FOOD_AND_DRINK_COFFEE"],
+            max_amount=50.0,
+            sort="date",
+            order="desc",
+        )
+        assert len(result) == 2
+        assert result[0]["date"] == "2026-01-15"
+        assert result[1]["date"] == "2026-01-10"

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1448,3 +1448,66 @@ class TestFilterTransactionsHelper:
         assert len(result) == 2
         assert result[0]["date"] == "2026-01-15"
         assert result[1]["date"] == "2026-01-10"
+
+
+class TestExportAdvancedFilters:
+    """Test /transactions/export honors advanced filter params."""
+
+    @pytest.fixture
+    def client(self, tmp_path):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        (output_dir / "enriched_transactions.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "date": "2026-01-15",
+                        "merchant_name": "Starbucks",
+                        "amount": -5.50,
+                        "category": "FOOD_AND_DRINK_COFFEE",
+                    },
+                    {
+                        "date": "2026-01-16",
+                        "merchant_name": "Shell Gas",
+                        "amount": -42.00,
+                        "category": "TRANSPORTATION_GAS",
+                    },
+                    {
+                        "date": "2026-01-01",
+                        "merchant_name": "Paycheck",
+                        "amount": 2500.00,
+                        "category": "INCOME_WAGES",
+                    },
+                ]
+            )
+        )
+        app = create_app(data_dir=str(tmp_path))
+        return TestClient(app)
+
+    def test_export_respects_min_amount(self, client):
+        response = client.get("/transactions/export?min_amount=10")
+        assert response.status_code == 200
+        text = response.text
+        assert "Shell Gas" in text
+        assert "Paycheck" in text
+        assert "Starbucks" not in text
+
+    def test_export_respects_category(self, client):
+        response = client.get("/transactions/export?categories=FOOD_AND_DRINK_COFFEE")
+        text = response.text
+        assert "Starbucks" in text
+        assert "Shell Gas" not in text
+
+    def test_export_respects_sort(self, client):
+        response = client.get("/transactions/export?sort=amount&order=desc")
+        text = response.text
+        assert text.index("Paycheck") < text.index("Starbucks")
+
+    def test_export_combines_filters(self, client):
+        response = client.get(
+            "/transactions/export?categories=FOOD_AND_DRINK_COFFEE,TRANSPORTATION_GAS&max_amount=50"
+        )
+        text = response.text
+        assert "Starbucks" in text
+        assert "Shell Gas" in text
+        assert "Paycheck" not in text

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1243,3 +1243,70 @@ class TestFilterTransactionsHelper:
         txns = self._sample_txns()
         result = _filter_transactions(txns, categories=[])
         assert len(result) == 3
+
+    def test_sort_by_date_asc(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, sort="date", order="asc")
+        assert [t["date"] for t in result] == ["2026-01-01", "2026-01-15", "2026-01-16"]
+
+    def test_sort_by_date_desc(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, sort="date", order="desc")
+        assert [t["date"] for t in result] == ["2026-01-16", "2026-01-15", "2026-01-01"]
+
+    def test_sort_by_amount_asc_uses_absolute_value(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, sort="amount", order="asc")
+        assert [t["merchant_name"] for t in result] == ["Starbucks", "Shell Gas", "Paycheck"]
+
+    def test_sort_by_amount_desc(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, sort="amount", order="desc")
+        assert [t["merchant_name"] for t in result] == ["Paycheck", "Shell Gas", "Starbucks"]
+
+    def test_sort_by_merchant_asc(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, sort="merchant", order="asc")
+        assert [t["merchant_name"] for t in result] == ["Paycheck", "Shell Gas", "Starbucks"]
+
+    def test_sort_by_category_asc(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, sort="category", order="asc")
+        assert [t["category"] for t in result] == [
+            "FOOD_AND_DRINK_COFFEE",
+            "INCOME_WAGES",
+            "TRANSPORTATION_GAS",
+        ]
+
+    def test_sort_defaults_to_asc_when_order_missing(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, sort="date")
+        assert [t["date"] for t in result] == ["2026-01-01", "2026-01-15", "2026-01-16"]
+
+    def test_unknown_sort_column_preserves_order(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, sort="nonexistent", order="asc")
+        assert [t["merchant_name"] for t in result] == ["Starbucks", "Shell Gas", "Paycheck"]
+
+    def test_no_sort_preserves_order(self):
+        from money_mapper.api.server import _filter_transactions
+
+        txns = self._sample_txns()
+        result = _filter_transactions(txns, sort=None)
+        assert [t["merchant_name"] for t in result] == ["Starbucks", "Shell Gas", "Paycheck"]


### PR DESCRIPTION
## Summary
- Sort by column (date, merchant, amount, category) with asc/desc/default cycle
- Amount range filter (min/max) with inclusive bounds
- Multi-select category filter with type-ahead autocomplete (datalist)
- Collapsible "Advanced Filters" panel with active-filter indicator
- All filters compose with existing text search and infinite scroll
- Export CSV reflects all active filters
- New `/api/categories` endpoint (cached PFC categories from plaid_categories.toml)
- Extracted shared `_filter_transactions()` helper used by both API and export endpoints

## Architecture
- All filtering/sorting server-side via query params on `/api/transactions` and `/transactions/export`
- Invalid params handled gracefully (ignored, not 422)
- No new dependencies, vanilla JS, no innerHTML

## Test plan
- [x] Unit tests for `_filter_transactions` helper (22 tests: text search, amount range, category, sort, composition)
- [x] API endpoint tests for new params (9 tests in TestTransactionsAPIAdvancedFilters)
- [x] Export endpoint tests (4 tests in TestExportAdvancedFilters)
- [x] `/api/categories` endpoint tests (3 tests in TestCategoriesAPI)
- [x] ruff check, ruff format, mypy, bandit all pass
- [x] 1199 tests passing, 59.32% coverage (threshold: 36%)
- [ ] Manual browser verification of UI interactions